### PR TITLE
Add .gitignore, requirements.txt, update Readme     

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # ci
+
+This repository contains ansible scripts and jenkins-job-builder definitions
+used by the quipucords team.
+
+It is advisable to install jenkins-job-builder in a virtual environment.
+
+# Installing dependencies in a virtual environment
+```
+ $ git clone https://github.com/quipucords/ci.git
+ $ cd ci
+ $ python3.6 -m venv ~/envs/quipu-jjb-env/
+ $ pip install -r requirements.txt
+```
+
+Note this does not install ansible, as it requires other system packages available through your
+package manager (yum, dnf, apt, ...).

--- a/jjb/requirements.txt
+++ b/jjb/requirements.txt
@@ -1,0 +1,2 @@
+# Packages required to generate jobs
+jenkins-job-builder

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+###### Requirements ######
+-r jjb/requirements.txt


### PR DESCRIPTION
~~Make it so user can install jjb dependencies in virtualenv with `python
setup.py install`. In the future, if other dependencies are added, they
can be added to setup.py and users can make sure they are using the
right packages and versions easily.~~
Make it so user can install jjb dependencies in virtualenv with `pip
install -r requirements.txt`.
    
In the future, if other dependencies are added, they can be added to
requirements.txt or jjb/requirements.txt. This will help users make
sure they are using the right packages and versions.

