### PR TITLE
Add job template for remote scan jobs.

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -8,3 +8,17 @@
             repo: 'fedora-25'
         - 'rhel7'
     repo: 'epel-7'
+- project:
+   name: rho-remote-scan
+   jobs:
+     - 'rho-nightly-remote-scan-{config}'
+   config:
+     - 'os':
+         config-file-id: '5e68dcca-4d9f-4470-b30c-ecc01121f53e'
+         time: '0 3 * * *'
+     - 'product':
+         config-file-id: '67f78386-fa45-4b68-a6d1-17bf97d5141d'
+         time: '0 2 * * *'
+     - 'individual':
+         config-file-id: 'b3e9ff0b-929e-473c-aca2-a9fa58d8dc41'
+         time: '0 1 * * *'

--- a/jjb/jobs/rho-nightly-remote-scan.yaml
+++ b/jjb/jobs/rho-nightly-remote-scan.yaml
@@ -1,0 +1,78 @@
+- job-template:
+    name: 'rho-nightly-remote-scan-{config}'
+    node: 'f25-np'
+    triggers:
+        - timed: '{time}'
+    scm:
+        - git:
+            url: https://github.com/quipucords/camayoc.git
+            basedir: camayoc
+            branches:
+                - '*/master'
+            skip-tag: true
+        - git:
+            url: https://github.com/quipucords/rho.git
+            basedir: rho
+            branches:
+                - '*/master'
+            skip-tag: true
+    wrappers:
+        - ssh-agent-credentials:
+            users:
+                - '390bdc1f-73c6-457e-81de-9e794478e0e'
+    builders:
+        - config-file-provider:
+            files:
+              - file-id: '{config-file-id}'
+                target: 'camayoc/config.yaml'
+        - shining-panda:
+            build-environment: virtualenv
+            python-version: System-CPython-3
+            nature: shell
+            command: |
+                cd rho
+                pip install -r requirements.txt
+                cd -
+                pip install ./camayoc[dev]
+
+                cat > .coveragerc <<EOF
+                [run]
+                concurrency=
+                    multiprocessing
+                    thread
+                data_file=${{PWD}}/.coverage
+                source=
+                    ${{PWD}}/rho/rho
+                EOF
+
+                export COVERAGE_PROCESS_START="${{PWD}}/.coveragerc"
+                RHO="$(which rho)"
+                sed -i '/#!/a import coverage; coverage.process_startup()' "${{RHO}}"
+
+                # Link RHO ansible modules
+                sudo mkdir -p /usr/share/ansible/rho/
+                sudo ln -s "${{PWD}}/rho/rho_playbook.yml" /usr/share/ansible/rho/
+                sudo ln -s "${{PWD}}/rho/library" /usr/share/ansible/rho/
+                sudo ln -s "${{PWD}}/rho/roles" /usr/share/ansible/rho/
+                export XDG_CONFIG_HOME=$PWD
+
+                set +e
+                pytest -v --junit-xml junit.xml camayoc/camayoc/tests/remote/
+                set -e
+
+                coverage combine
+                coverage report
+                coverage xml
+    publishers:
+        - junit:
+            results: junit.xml
+        - cobertura:
+            fail-no-reports: true
+            report-file: coverage.xml
+            source-encoding: UTF_8
+            targets:
+                - line:
+                    healthy: 80
+                    unhealthy: 50
+                    failing: 0
+        - mark-node-offline


### PR DESCRIPTION
Generates jenkins jobs that run against remote machines using config
files present on jenkins nightly at different times.

Note that we cannot run these in parallel, so we don't use pytest-xdist.

Exactly what tests these jobs performed is determined by the config file present on jenkins.