### PR TITLE
Work around ansible 2.4 bug for now

### DIFF
--- a/jjb/jobs/rho-nightly-remote-scan.yaml
+++ b/jjb/jobs/rho-nightly-remote-scan.yaml
@@ -55,7 +55,10 @@
                 sudo ln -s "${{PWD}}/rho/library" /usr/share/ansible/rho/
                 sudo ln -s "${{PWD}}/rho/roles" /usr/share/ansible/rho/
                 export XDG_CONFIG_HOME=$PWD
-
+                # begin work around for issue #15
+                # see https://github.com/quipucords/ci/issues/15
+                pip install ansible==2.3.2
+                # end work around
                 set +e
                 pytest -v --junit-xml junit.xml camayoc/camayoc/tests/remote/
                 set -e


### PR DESCRIPTION
Use the last known good version of ansible for now. Camayoc
needs to use python 3, but there is currently a bug in the 2.4 ansible
release that rho pulls in via pip.

Closes #15