### PR TITLE
ansible role to install jboss

### DIFF
--- a/ansible/jboss-eap-install.yaml
+++ b/ansible/jboss-eap-install.yaml
@@ -1,0 +1,34 @@
+- hosts: all
+  roles:
+    - role: subscription-manager
+      when: ansible_distribution == 'RedHat'
+    - role: jboss_eap_install
+
+# To use this playbook, provide the following variables:
+# ansible-playbook -i /path/to/hosts jboss-eap-install.yaml \
+# -e jboss_zip_path=/path/to/jboss-eap-7.0.0.zip
+#
+# You can register a RHEL 7 system with subscription manager by providing your
+# username and password:
+#
+# -e rhn_username=USERNAME -e rhn_password=PASSWORD
+#
+# By providing the following variables, you can provide a custom rhsm server
+# and base url to subscription-manager
+#
+# -e custom_baseurl=CDNURL \
+# -e custom_server=SERVERURL \
+#
+#
+# Other optional variables:
+#
+# jboss_install_dir:
+#     The name of the directory created when you unpack the jboss zip file
+# jboss_log_dir:
+#     Path to the directory where jboss will put its logs
+# jboss_service_name:
+#     Name that the service will be called, i.e. what systemctl will know it as
+# jboss_home_dir:
+#     Home directory of jboss user, where the jboss zip will be unpacked
+# jboss_username:
+#     Name of the jboss user, who will own the process running jboss

--- a/ansible/jboss-eap-install.yaml
+++ b/ansible/jboss-eap-install.yaml
@@ -22,13 +22,14 @@
 #
 # Other optional variables:
 #
-# jboss_install_dir:
-#     The name of the directory created when you unpack the jboss zip file
+# jboss_base_dir:
+#     The directory in which the zip file will be unpacked (parent eventual
+#     to JBOSS_HOME i.e., where this jboss install will actually be)
 # jboss_log_dir:
 #     Path to the directory where jboss will put its logs
 # jboss_service_name:
 #     Name that the service will be called, i.e. what systemctl will know it as
-# jboss_home_dir:
-#     Home directory of jboss user, where the jboss zip will be unpacked
+# jboss_user_dir:
+#     Home directory of jboss user
 # jboss_username:
 #     Name of the jboss user, who will own the process running jboss

--- a/ansible/roles/jboss_eap_install/defaults/main.yaml
+++ b/ansible/roles/jboss_eap_install/defaults/main.yaml
@@ -1,0 +1,4 @@
+jboss_zip_path: 'jboss-eap-7.0.0.zip'
+jboss_install_dir: 'jboss-eap-7.0'
+jboss_log_dir: '/var/log/jboss'
+jboss_service_name: 'jboss-eap-7'

--- a/ansible/roles/jboss_eap_install/defaults/main.yaml
+++ b/ansible/roles/jboss_eap_install/defaults/main.yaml
@@ -1,4 +1,4 @@
 jboss_zip_path: 'jboss-eap-7.0.0.zip'
-jboss_install_dir: 'jboss-eap-7.0'
+jboss_base_dir: '{{jboss_user_dir}}'
 jboss_log_dir: '/var/log/jboss'
 jboss_service_name: 'jboss-eap-7'

--- a/ansible/roles/jboss_eap_install/meta/main.yaml
+++ b/ansible/roles/jboss_eap_install/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: setup_jboss_user }

--- a/ansible/roles/jboss_eap_install/tasks/main.yaml
+++ b/ansible/roles/jboss_eap_install/tasks/main.yaml
@@ -7,21 +7,41 @@
       - java-1.8.0-openjdk
       - java-1.8.0-openjdk-headless
 
-  - name: Unpack jboss zip into jboss user home
+  - name: Ensure base dir that jboss will be installed into and log dir exists
+    file:
+      path: '{{item}}'
+      state: directory
+      owner: '{{jboss_username}}'
+      group: '{{jboss_username}}'
+      mode: 0755
+    with_items:
+        - '{{jboss_base_dir}}'
+        - '{{jboss_log_dir}}'
+
+  - name: Unpack jboss zip into base dir
     unarchive:
       copy: True
       src: '{{jboss_zip_path}}'
-      dest: '{{jboss_home_dir}}/'
+      dest: '{{jboss_base_dir}}/'
       group: '{{jboss_username}}'
       mode: "0644"
       owner: '{{jboss_username}}'
+      list_files: True
+    register: unzip_result
+
+  - name: Set name of jboss install dir based on unzip task
+    set_fact:
+        jboss_install_dir: "{{jboss_base_dir}}/{{unzip_result['files'][0]}}"
+
+  - debug:
+      msg: install dir is now {{jboss_install_dir}}
 
   - name: Ensure jboss user can read all dirs
-    command: 'find {{ jboss_home_dir }} -type d -exec chmod -c 0755 {} \;'
+    command: 'find {{ jboss_install_dir }} -type d -exec chmod -c 0755 {} \;'
 
   - name: Make standalone.sh executable
     file:
-        path: '{{jboss_home_dir}}/{{jboss_install_dir}}/bin/standalone.sh'
+        path: '{{jboss_install_dir}}/bin/standalone.sh'
         mode: 'u=rwx'
         state: 'touch'
 

--- a/ansible/roles/jboss_eap_install/tasks/main.yaml
+++ b/ansible/roles/jboss_eap_install/tasks/main.yaml
@@ -1,0 +1,43 @@
+- block:
+  - name: Install packages required for jboss
+    action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+    with_items:
+      - unzip
+      - java-1.8.0-openjdk-devel
+      - java-1.8.0-openjdk
+      - java-1.8.0-openjdk-headless
+
+  - name: Unpack jboss zip into jboss user home
+    unarchive:
+      copy: True
+      src: '{{jboss_zip_path}}'
+      dest: '{{jboss_home_dir}}/'
+      group: '{{jboss_username}}'
+      mode: "0644"
+      owner: '{{jboss_username}}'
+
+  - name: Ensure jboss user can read all dirs
+    command: 'find {{ jboss_home_dir }} -type d -exec chmod -c 0755 {} \;'
+
+  - name: Make standalone.sh executable
+    file:
+        path: '{{jboss_home_dir}}/{{jboss_install_dir}}/bin/standalone.sh'
+        mode: 'u=rwx'
+        state: 'touch'
+
+  - name: Install standalone.conf file
+    template:
+        src: standalone.conf.j2
+        dest: '/etc/default/{{jboss_service_name}}.conf'
+
+  - name: Install systemd unit file
+    template:
+        src: jboss_eap.service.j2
+        dest: '/usr/lib/systemd/system/{{jboss_service_name}}.service'
+
+  - name: Run daemon reload
+    shell: "systemctl daemon-reload"
+
+  - name: Start services
+    service: "name={{jboss_service_name}} state=started enabled=yes"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6

--- a/ansible/roles/jboss_eap_install/templates/jboss_eap.service.j2
+++ b/ansible/roles/jboss_eap_install/templates/jboss_eap.service.j2
@@ -7,8 +7,8 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/{{jboss_service_name}}.conf
 User={{jboss_username}}
 Group={{jboss_username}}
-WorkingDirectory={{jboss_home_dir}}/{{jboss_install_dir}}/bin/
-ExecStart={{jboss_home_dir}}/{{jboss_install_dir}}/bin/standalone.sh
+WorkingDirectory={{jboss_install_dir}}/bin/
+ExecStart={{jboss_install_dir}}/bin/standalone.sh
 
 [Install]
 WantedBy=default.target

--- a/ansible/roles/jboss_eap_install/templates/jboss_eap.service.j2
+++ b/ansible/roles/jboss_eap_install/templates/jboss_eap.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=JBoss EAP
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=/etc/default/{{jboss_service_name}}.conf
+User={{jboss_username}}
+Group={{jboss_username}}
+WorkingDirectory={{jboss_home_dir}}/{{jboss_install_dir}}/bin/
+ExecStart={{jboss_home_dir}}/{{jboss_install_dir}}/bin/standalone.sh
+
+[Install]
+WantedBy=default.target

--- a/ansible/roles/jboss_eap_install/templates/standalone.conf.j2
+++ b/ansible/roles/jboss_eap_install/templates/standalone.conf.j2
@@ -4,7 +4,7 @@
 ##                                                                          ##
 ##############################################################################
 
-JBOSS_HOME='{{jboss_home_dir}}/{{jboss_install_dir}}'
+JBOSS_HOME='{{jboss_install_dir}}'
 
 ## The username who should own the process.
 JBOSS_USER={{jboss_username}}

--- a/ansible/roles/jboss_eap_install/templates/standalone.conf.j2
+++ b/ansible/roles/jboss_eap_install/templates/standalone.conf.j2
@@ -1,0 +1,19 @@
+## -*- shell-script -*- ######################################################
+##                                                                          ##
+##  JBoss EAP Bootstrap Script Configuration                                ##
+##                                                                          ##
+##############################################################################
+
+JBOSS_HOME='{{jboss_home_dir}}/{{jboss_install_dir}}'
+
+## The username who should own the process.
+JBOSS_USER={{jboss_username}}
+
+## The mode JBoss EAP should start, standalone or domain
+JBOSS_MODE=standalone
+
+JBOSS_MODULES_SYSTEM_PKGS='org.jboss.byteman'
+
+JBOSS_LOG_DIR='{{jboss_log_dir}}'
+
+JAVA_OPTS='-Xms1024m -Xmx20480m -XX:MaxPermSize=768m'

--- a/ansible/roles/setup_jboss_user/defaults/main.yaml
+++ b/ansible/roles/setup_jboss_user/defaults/main.yaml
@@ -1,2 +1,2 @@
-jboss_home_dir: '/opt/jboss'
+jboss_user_dir: '/opt/jboss'
 jboss_username: 'jboss'

--- a/ansible/roles/setup_jboss_user/defaults/main.yaml
+++ b/ansible/roles/setup_jboss_user/defaults/main.yaml
@@ -1,0 +1,2 @@
+jboss_home_dir: '/opt/jboss'
+jboss_username: 'jboss'

--- a/ansible/roles/setup_jboss_user/tasks/main.yml
+++ b/ansible/roles/setup_jboss_user/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Ceate jboss user with custom home directory.
+  user:
+    createhome: yes
+    name: '{{jboss_username}}'
+    home: '{{jboss_home_dir}}'

--- a/ansible/roles/setup_jboss_user/tasks/main.yml
+++ b/ansible/roles/setup_jboss_user/tasks/main.yml
@@ -2,4 +2,4 @@
   user:
     createhome: yes
     name: '{{jboss_username}}'
-    home: '{{jboss_home_dir}}'
+    home: '{{jboss_user_dir}}'

--- a/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ansible/roles/subscription-manager/tasks/main.yaml
@@ -1,0 +1,36 @@
+---
+
+# Playbooks should conditionally include this role by placing the following
+# assertion into a `when:` statement.
+- name: Ensure expected distribution
+  assert:
+    that: ansible_distribution == "RedHat"
+
+# De-registering and then registering is equivalent to using the
+# `force_register` argument, which was added in Ansible 2.2. We use this
+# technique to preserve compatibility with RHEL 6.
+- name: subscription-manager de-register
+  redhat_subscription:
+    state: absent
+  when:
+    - rhn_username is defined
+    - rhn_password is defined
+
+- name: Edit rhsm.conf
+  shell: 'subscription-manager config --server.hostname {{custom_server}} --server.insecure 1 --rhsm.baseurl {{custom_baseurl}}'
+  when:
+      - custom_baseurl is defined
+      - custom_server is defined
+
+- name: subscription-manager register and subscribe by username and password
+  redhat_subscription:
+    username: "{{ rhn_username }}"
+    password: "{{ rhn_password }}"
+    autosubscribe: True
+  ignore_errors: yes
+  when:
+    - rhn_username is defined
+    - rhn_password is defined
+
+- name: Enable EPEL repository
+  action: "{{ ansible_pkg_mgr }} name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"


### PR DESCRIPTION
This branch contains:
* role to register a RHEL machine with subscription manager, optionally using a custom CDN (i.e. our stage environment). 
* role to create a jboss user, install jboss, and install necessary files to run jboss on boot with systemd

I've marked it WIP for now because I  want to get some feed back on the work flow.

Message me and I can provide you with more details on where to get the jboss zip and what variables you need to provide to the subscription manager role.