### PR TITLE
Update rho remote scan job

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -8,17 +8,3 @@
             repo: 'fedora-25'
         - 'rhel7'
     repo: 'epel-7'
-- project:
-   name: rho-remote-scan
-   jobs:
-     - 'rho-nightly-remote-scan-{config}'
-   config:
-     - 'os':
-         config-file-id: '5e68dcca-4d9f-4470-b30c-ecc01121f53e'
-         time: '0 3 * * *'
-     - 'product':
-         config-file-id: '67f78386-fa45-4b68-a6d1-17bf97d5141d'
-         time: '0 2 * * *'
-     - 'individual':
-         config-file-id: 'b3e9ff0b-929e-473c-aca2-a9fa58d8dc41'
-         time: '0 1 * * *'

--- a/jjb/jobs/rho-nightly-remote-scan.yaml
+++ b/jjb/jobs/rho-nightly-remote-scan.yaml
@@ -1,8 +1,8 @@
-- job-template:
-    name: 'rho-nightly-remote-scan-{config}'
+- job:
+    name: 'rho-nightly-remote-scan'
     node: 'f25-np'
     triggers:
-        - timed: '{time}'
+        - timed: '@midnight'
     scm:
         - git:
             url: https://github.com/quipucords/camayoc.git
@@ -23,13 +23,16 @@
     builders:
         - config-file-provider:
             files:
-              - file-id: '{config-file-id}'
+              - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
                 target: 'camayoc/config.yaml'
         - shining-panda:
             build-environment: virtualenv
             python-version: System-CPython-3
             nature: shell
+            system-site-packages: true
             command: |
+                sudo dnf -y install libselinux-python3
+
                 # Make sure the path $HOME/.ssh/id_rsa is a valid path in order
                 # to not fail the rho auth validation for the sshkeypath. Even
                 # though this will be an empty file, the SSH key used will come
@@ -62,10 +65,6 @@
                 sudo ln -s "${{PWD}}/rho/library" /usr/share/ansible/rho/
                 sudo ln -s "${{PWD}}/rho/roles" /usr/share/ansible/rho/
                 export XDG_CONFIG_HOME=$PWD
-                # begin work around for issue #15
-                # see https://github.com/quipucords/ci/issues/15
-                pip install ansible==2.3.2
-                # end work around
                 set +e
                 pytest -v --junit-xml junit.xml camayoc/camayoc/tests/remote/
                 set -e


### PR DESCRIPTION
After recent changes on Camayoc now the remote scan job is meant to be a
single job which will scan every machine available in the configuration
file's inventory section. Update the rho remote scan job definition to
match this new way of performing the remote scan.

Close #30