### PR TITLE
Disable authentication while running quipucords

### DIFF
--- a/jjb/jobs/qcs-nightly-automation.yaml
+++ b/jjb/jobs/qcs-nightly-automation.yaml
@@ -41,7 +41,7 @@
                 pip install -r requirements.txt
                 make server-init
                 # run server in background and collect its PID
-                nohup make serve > $WORKSPACE/server.log 2>&1 &
+                nohup make serve QPC_DISABLE_AUTHENTICATION=True > $WORKSPACE/server.log 2>&1 &
                 export SERVERPID=$!
 
                 cd -


### PR DESCRIPTION
We need to run the server with authentication disabled until camayoc is
updated to use the token authentication with API and CLI tests.

Closes #39 