### PR TITLE
Run the quipucords server with auth enabled

### DIFF
--- a/jjb/jobs/qcs-nightly-automation.yaml
+++ b/jjb/jobs/qcs-nightly-automation.yaml
@@ -41,7 +41,7 @@
                 pip install -r requirements.txt
                 make server-init
                 # run server in background and collect its PID
-                nohup make serve QPC_DISABLE_AUTHENTICATION=True > $WORKSPACE/server.log 2>&1 &
+                nohup make serve > $WORKSPACE/server.log 2>&1 &
                 export SERVERPID=$!
 
                 cd -


### PR DESCRIPTION
Now that camayoc PR #123
(https://github.com/quipucords/camayoc/pull/123) is closed, we can run
the server without disabling authentication.