### PR TITLE
Update config file id

### DIFF
--- a/jjb/jobs/qcs-nightly-automation.yaml
+++ b/jjb/jobs/qcs-nightly-automation.yaml
@@ -21,7 +21,7 @@
     builders:
         - config-file-provider:
             files:
-              - file-id: '2c2b5dc8-3794-4d62-b49a-c3968cd5843a'
+              - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
                 target: 'camayoc/config.yaml'
         - shining-panda:
             build-environment: virtualenv


### PR DESCRIPTION
Now that the issue quipucords/camayoc/#110 is closed, rho and quipucords jobs
use the same config file format.

This commit updates the id so both use the same file on Jenkins.