### PR TITLE
Create nightly job to test pilot package and container

### DIFF
--- a/jjb/jobs/qcs-PILOT-nightly-automation.yaml
+++ b/jjb/jobs/qcs-PILOT-nightly-automation.yaml
@@ -1,5 +1,5 @@
 - job:
-    name: 'qcs-nightly-automation'
+    name: 'qcs-PILOT-nightly-automation'
     node: 'f27-os'
     triggers:
         - timed: '@midnight'
@@ -8,7 +8,7 @@
             url: https://github.com/quipucords/camayoc.git
             basedir: camayoc
             branches:
-                - '*/master'
+                - '*/quipucords/pilot'
             skip-tag: true
     wrappers:
         - credentials-binding:
@@ -23,6 +23,12 @@
             files:
               - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
                 target: 'camayoc/config.yaml'
+        - copyartifact:
+                project: qpc_docker_beta
+                filter: quipucords.*.tar.gz
+                target: ${WORKSPACE}/container/
+                stable: true
+
         - shining-panda:
             build-environment: virtualenv
             python-version: System-CPython-3.6
@@ -32,22 +38,28 @@
                 mkdir -p /home/jenkins/.ssh
                 cp "${ID_JENKINS_RSA}" /home/jenkins/.ssh/id_rsa
                 chmod 0600 /home/jenkins/.ssh/id_rsa
+                
+                # rename container to something without long hash
+                mv ${WORKSPACE}/container/quipucords* quipucords.pilot.tar.gz
 
                 sed -i "s/{jenkins_slave_ip}/${OPENSTACK_PUBLIC_IP}/" camayoc/config.yaml
 
                 echo "OPTIONS=--log-driver=journald" > docker.conf
                 echo "DOCKER_CERT_PATH=/etc/docker" >> docker.conf
-                echo "INSECURE_REGISTRY=\"--insecure-registry ${DOCKER_REGISTRY}\"" >> docker.conf
                 sudo cp docker.conf /etc/sysconfig/docker
                 sudo systemctl start docker
-                sudo docker pull "${DOCKER_REGISTRY}/quipucords/quipucords:latest"
+                echo "load docker container from tarball"
+                sudo docker load -i ${WORKSPACE}/quipucords.pilot.tar.gz
+
                 # make log dir to save server logs
                 mkdir ${WORKSPACE}/log
-                # run container binding local ssh keys and log dir to the container
-                sudo docker run -d -p "443:443" -v /tmp:/tmp -v /home/jenkins/.ssh:/home/jenkins/.ssh -v ${WORKSPACE}/log:/var/log -i "${DOCKER_REGISTRY}/quipucords/quipucords:latest"
+                # run docker container, mounting local volumes for logs and ssh keys 
+                sudo docker run -d -p "443:443" -v /tmp:/tmp -v /home/jenkins/.ssh:/home/jenkins/.ssh -v ${WORKSPACE}/log:/var/log -i "quipucords:pilot"
 
+                # Install qpc from rpm
                 sudo wget -O /etc/yum.repos.d/chambridge-qpc-fedora-27.repo https://copr.fedorainfracloud.org/coprs/chambridge/qpc/repo/fedora-27/chambridge-qpc-fedora-27.repo
-                sudo dnf -y install qpc
+                # build specific qpc package for pilot
+                sudo dnf -y install qpc-0.0.1-1.git.342.44b5e58.fc27.noarch
 
                 # create pytest configuration file to ignore the insecure
                 # requests warnings that talking to the server over https


### PR DESCRIPTION
Also update nightly job testing the lastest container to archive logs and quiet
down the noise in the py.test console output about insecure requests made to
the container.

Closes #53