### PR TITLE
Update rho nightly scan to only run rho tests

### DIFF
--- a/jjb/jobs/rho-nightly-remote-scan.yaml
+++ b/jjb/jobs/rho-nightly-remote-scan.yaml
@@ -66,7 +66,7 @@
                 sudo ln -s "${PWD}/rho/roles" /usr/share/ansible/rho/
                 export XDG_CONFIG_HOME=$PWD
                 set +e
-                pytest -v --junit-xml junit.xml camayoc/camayoc/tests/remote/
+                pytest -v --junit-xml junit.xml camayoc/camayoc/tests/remote/rho/
                 set -e
 
                 coverage combine


### PR DESCRIPTION
There is now another module underneath `camayoc/camayoc/tests/remote/` 
that does not make sense to run concurrently with the rho tests. 
We must specify the `rho` subdirectory.