### PR TITLE
Create jobs to verify install of pilot container

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -12,3 +12,26 @@
             repo: 'fedora-27'
         - 'rhel7'
     repo: 'epel-7'
+
+- project:
+    name:  quipucords-PILOT-container-install
+    jobs:
+        - 'qcs-PILOT-container-install-{distro}'
+    distro:
+        - 'f27':
+            repo-name: 'chambridge-qpc-fedora-27.repo'
+            repo-url: 'https://copr.fedorainfracloud.org/coprs/chambridge/qpc/repo/fedora-27/chambridge-qpc-fedora-27.repo'
+            rpm-name: 'qpc-0.0.1-1.git.342.44b5e58.fc27.noarch'
+            package-manager: 'dnf'
+
+        - 'rhel7':
+            repo-name: 'chambridge-qpc-epel-7.repo'
+            repo-url: 'https://copr.fedorainfracloud.org/coprs/chambridge/qpc/repo/epel-7/chambridge-qpc-epel-7.repo'
+            rpm-name: 'qpc-0.0.1-1.git.342.44b5e58.el7.centos'
+            package-manager: 'yum'
+        
+        - 'rhel6':
+            repo-name: 'chambridge-qpc-epel-6.repo'
+            repo-url: 'https://copr.fedorainfracloud.org/coprs/chambridge/qpc/repo/epel-6/chambridge-qpc-epel-6.repo'
+            rpm-name: 'qpc-0.0.1-1.git.342.44b5e58.el6'
+            package-manager: 'yum'

--- a/jjb/jobs/qcs-PILOT-container-install.yaml
+++ b/jjb/jobs/qcs-PILOT-container-install.yaml
@@ -1,0 +1,92 @@
+- job-template:
+    name: 'qcs-PILOT-container-install-{distro}'
+    node: '{distro}-os'
+    triggers:
+        - timed: '@midnight'
+    scm:
+        - git:
+            url: https://github.com/quipucords/ci.git
+            basedir: ci
+            skip-tag: true
+            branches:
+              - origin/issues/50
+    wrappers:
+        - inject:
+            properties-content: |
+                DISTRO={distro}
+        - credentials-binding:
+            - file:
+                credential-id: 4c692211-c5e1-4354-8e1b-b9d0276c29d9
+                variable: ID_JENKINS_RSA
+        - ssh-agent-credentials:
+            users:
+                - '390bdc1f-73c6-457e-81de-9e794478e0e'
+    builders:
+        - config-file-provider:
+            files:
+              - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
+                target: 'camayoc/config.yaml'
+
+        - shining-panda:
+            build-environment: virtualenv
+            python-version: Default-System-Python2
+            nature: shell
+            command: |
+                export XDG_CONFIG_HOME=$PWD
+                mkdir -p /home/jenkins/.ssh
+                cp "${{ID_JENKINS_RSA}}" /home/jenkins/.ssh/id_rsa
+                chmod 0600 /home/jenkins/.ssh/id_rsa
+
+                set +e # don't want to fail if epel is allready installed
+                if [ "${{DISTRO}}" = "rhel7" ]; then
+                        wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+                        sudo rpm -ivh epel-release-latest-7.noarch.rpm
+                fi
+                if [ "${{DISTRO}}" = "rhel6" ]; then
+                        wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+                        sudo rpm -ivh epel-release-6-8.noarch.rpm
+                        curl -k -O -sSL https://yum.dockerproject.org/repo/main/centos/6/Packages/docker-engine-1.7.1-1.el6.x86_64.rpm
+                        sudo yum localinstall -nogpgcheck docker-engine-1.7.1-1.el6.x86_64.rpm
+                        sudo service docker start
+                        sudo docker run hello-world
+                        sudo chkconfig docker on
+                fi
+                set -e
+                
+                echo "OPTIONS=--log-driver=journald" > docker.conf
+                echo "DOCKER_CERT_PATH=/etc/docker" >> docker.conf
+                sudo cp docker.conf /etc/sysconfig/docker
+
+                if [ "${{DISTRO}}" = "rhel7" ] || [ "${{DISTRO}}" = "f27" ]; then
+                        sudo systemctl start docker
+                fi
+                echo "load docker container from tarball"
+                curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/0.0.1-pilot/quipucords.pilot.e9ccd8cc05e41ee555f768eb2692f785aaf7e942.tar.gz
+                mv quipucords.pilot* quipucords.pilot.tar.gz
+                sudo docker load -i ${{WORKSPACE}}/quipucords.pilot.tar.gz
+
+                # make log dir to save server logs
+                mkdir ${{WORKSPACE}}/log
+                # run docker container, mounting local volumes for logs and ssh keys 
+                sudo docker run -d -p "443:443" -v /tmp:/tmp -v /home/jenkins/.ssh:/home/jenkins/.ssh -v ${{WORKSPACE}}/log:/var/log -i "quipucords:pilot"
+
+                # Install qpc from rpm
+                sudo wget -O /etc/yum.repos.d/{repo-name} {repo-url}
+                # build specific qpc package for pilot
+                sudo {package-manager} -y install {rpm-name}
+
+                pip install pexpect nose
+                set +e
+                nosetests --with-xunit --xunit-file=junit.xml ci/scripts/quipucords/pilot/install/test_install.py
+                set -e
+
+                # Archive server logs to aid in analyzing test failures
+                cd ${{WORKSPACE}}
+                tar -cvzf server-logs.tar.gz ${{WORKSPACE}}/log
+    publishers:
+        - junit:
+            results: junit.xml
+        - archive:
+            artifacts: 'server-logs.tar.gz'
+            allow-empty: false
+        - mark-node-offline

--- a/jjb/jobs/qcs-PILOT-nightly-automation.yaml
+++ b/jjb/jobs/qcs-PILOT-nightly-automation.yaml
@@ -23,11 +23,6 @@
             files:
               - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
                 target: 'camayoc/config.yaml'
-        - copyartifact:
-                project: qpc_docker_beta
-                filter: quipucords.*.tar.gz
-                target: ${WORKSPACE}/container/
-                stable: true
 
         - shining-panda:
             build-environment: virtualenv
@@ -39,9 +34,6 @@
                 cp "${ID_JENKINS_RSA}" /home/jenkins/.ssh/id_rsa
                 chmod 0600 /home/jenkins/.ssh/id_rsa
                 
-                # rename container to something without long hash
-                mv ${WORKSPACE}/container/quipucords* quipucords.pilot.tar.gz
-
                 sed -i "s/{jenkins_slave_ip}/${OPENSTACK_PUBLIC_IP}/" camayoc/config.yaml
 
                 echo "OPTIONS=--log-driver=journald" > docker.conf
@@ -49,6 +41,8 @@
                 sudo cp docker.conf /etc/sysconfig/docker
                 sudo systemctl start docker
                 echo "load docker container from tarball"
+                curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/0.0.1-pilot/quipucords.pilot.e9ccd8cc05e41ee555f768eb2692f785aaf7e942.tar.gz
+                mv quipucords.pilot* quipucords.pilot.tar.gz
                 sudo docker load -i ${WORKSPACE}/quipucords.pilot.tar.gz
 
                 # make log dir to save server logs

--- a/scripts/quipucords/pilot/install/test_install.py
+++ b/scripts/quipucords/pilot/install/test_install.py
@@ -1,0 +1,69 @@
+"""Test to confirm functional install of quipucords server."""
+
+import unittest
+import pexpect
+
+from io import BytesIO
+
+
+class TestInstall(unittest.TestCase):
+    """Test that we can log in and create items on the server.
+
+    The intent of this test is to verify that the install is functional.
+    """
+
+    def test_all(self):
+        command = 'qpc server config --host 127.0.0.1'
+        qpc_server_config = pexpect.spawn(command)
+        qpc_server_config.logfile = BytesIO()
+        assert qpc_server_config.expect(pexpect.EOF) == 0
+        qpc_server_config.close()
+        assert qpc_server_config.exitstatus == 0
+
+        # now login to the server
+        command = 'qpc server login --username admin'
+        qpc_server_login = pexpect.spawn(command)
+        qpc_server_config.logfile = BytesIO()
+        assert qpc_server_login.expect('Password: ') == 0
+        qpc_server_login.sendline('pass')
+        assert qpc_server_login.expect(pexpect.EOF) == 0
+        qpc_server_login.close()
+        output = qpc_server_config.logfile.getvalue().decode('utf-8')
+        if not qpc_server_login.exitstatus == 0:
+            raise AssertionError(output)
+
+        # Create credential, source, and scan
+        command = 'qpc cred add --type network --username example --name example --password'
+        qpc_cred_add = pexpect.spawn(command)
+        qpc_cred_add.logfile = BytesIO()
+        assert qpc_cred_add.expect('Password: ') == 0
+        qpc_cred_add.sendline('pass')
+        assert qpc_cred_add.expect(pexpect.EOF) == 0
+        qpc_cred_add.close()
+        output = qpc_cred_add.logfile.getvalue().decode('utf-8')
+        if not qpc_cred_add.exitstatus == 0:
+            raise AssertionError(output)
+
+        command = 'qpc source add --type network  --hosts localhost --name example --cred example'
+        qpc_source_add = pexpect.spawn(command)
+        qpc_source_add.logfile = BytesIO()
+        assert qpc_source_add.expect(pexpect.EOF) == 0
+        qpc_source_add.close()
+        output = qpc_source_add.logfile.getvalue().decode('utf-8')
+        if not qpc_source_add.exitstatus == 0:
+            raise AssertionError(output)
+
+        command = 'qpc scan start --sources example'
+        qpc_scan_add = pexpect.spawn(command)
+        qpc_scan_add.logfile = BytesIO()
+        assert qpc_scan_add.expect(pexpect.EOF) == 0
+        qpc_scan_add.close()
+        output = qpc_scan_add.logfile.getvalue().decode('utf-8')
+        if not qpc_scan_add.exitstatus == 0:
+            raise AssertionError(output)
+
+    def tearDown(self):
+        for item in ['scan', 'source', 'cred']:
+            qpc_command = pexpect.spawn('qpc {0} clear --all'.format(item))
+            qpc_command.expect(pexpect.EOF)
+            qpc_command.close()


### PR DESCRIPTION
Verify install on RHEL 6 and 7 as well as Fedora 27 from github release
tarball.  Adds python 2 compliant install validation test for pilot.

Also updates nightly pilot automation job to use github release image as well.
This job is distinct in that it runs entire camayoc test suite against the container, where as the `qcs-container-install` jobs only verify that the install method was successful.

Closes #50
Closes #56