### PR TITLE
Update setup_scan_users role

### DIFF
--- a/ansible/roles/setup_scan_users/tasks/main.yml
+++ b/ansible/roles/setup_scan_users/tasks/main.yml
@@ -94,6 +94,14 @@
     name: libselinux-python
     state: latest
     disable_gpg_check: yes
+  ignore_errors: true
+
+- name: Add python3-libselinux support.
+  package:
+    name: python3-libselinux
+    state: latest
+    disable_gpg_check: yes
+  ignore_errors: true
 
 - name: Set authorized key from file for root.
   authorized_key:


### PR DESCRIPTION
Either install libselinux-python or python3-libselinux depending on the
package available on the repositories.