### PR TITLE
Remove master condition

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -16,7 +16,7 @@
     jobs:
       - 'qpc-{release}-container-install-{distro}'
     release:
-      - 'released'
+      - '0.0.46'
     distro:
       - 'f27'
       - 'f28'

--- a/jjb/jobs/qpc-container-install.yaml
+++ b/jjb/jobs/qpc-container-install.yaml
@@ -60,26 +60,22 @@
                         sudo yum-config-manager --disable optional
                 fi
 
-                sudo yum -y install ansible python-pip
+                sudo dnf -y install python-pip
 
                 set -e
 
-                if [ "${{RELEASE}}" = "released" ]; then
-                        rm quipucords.*.tar.gz
-                        echo "load docker container from tarball"
-                        curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/0.0.44/quipucords.install.tar.gz
-                fi
+
+                rm quipucords.*.tar.gz
+                echo "load docker container from tarball"
+                curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/${{RELEASE}}/quipucords.${{RELEASE}}.install.tar.gz
+
                 echo "extract the installer into ${{WORKSPACE}}/install"
-                tar -xvzf ${{WORKSPACE}}/quipucords.install.tar.gz
+                tar -xvzf ${{WORKSPACE}}/quipucords.${{RELEASE}}.install.tar.gz
 
-                if [ "${{RELEASE}}" = "master" ]; then
-                        echo "copy container to installer packages directory"
-                        mkdir -p ${{WORKSPACE}}/install/packages
-                        mv quipucords.master.tar.gz ${{WORKSPACE}}/install/packages/
-                fi
-
-                echo "Execute ansible playbook to install"
-                sudo ansible-playbook -v ${{WORKSPACE}}/install/qpc_playbook.yml -e server_install_dir=${{WORKSPACE}}
+                echo "Execute install.sh to install"
+                cd ${{WORKSPACE}}/install/
+                sudo ${{WORKSPACE}}/install/install.sh -e server_install_dir=${{WORKSPACE}}
+                cd ${{WORKSPACE}}
 
                 sudo pip install pexpect nose
                 set +e

--- a/jjb/jobs/qpc-container-install.yaml
+++ b/jjb/jobs/qpc-container-install.yaml
@@ -59,11 +59,11 @@
                         sudo yum-config-manager --disable base
                         sudo yum-config-manager --disable optional
                 fi
-
+                
+                echo "Install python-pip"
                 sudo dnf -y install python-pip
 
                 set -e
-
 
                 rm quipucords.*.tar.gz
                 echo "load docker container from tarball"


### PR DESCRIPTION
- Removed the master/release conditionals since the master jobs have been offloaded to their own templates. This template will be used just for releases now.
- Updated release specified to 0.0.46.
- updated quipucords download source
- switched to using install.sh install method instead of manually running the ansible playbooks