### PR TITLE
Added conditional for nosupervisord install pipelines

### DIFF
--- a/jjb/include/pipelines/qpc-release-test-install.groovy
+++ b/jjb/include/pipelines/qpc-release-test-install.groovy
@@ -10,6 +10,27 @@ def setupDocker() {{
     '''.stripIndent()
 }}
 
+def installQPC() {{
+    echo "Execute install.sh to install"
+    dir("${{WORKSPACE}}/install") {{
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'sudo ./install.sh -e server_install_dir=${{WORKSPACE}}'
+    }}
+}}
+
+def installQPCNoSupervisorD() {{
+    echo "Execute install.sh to install without supervisord"
+    dir("${{WORKSPACE}}/install") {{
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'sudo ./install.sh -e server_install_dir=${{WORKSPACE}} -e use_supervisord=false'
+
+        // Docker log to check for supervisord
+        sh 'sudo docker ps -a'
+        sh 'sudo docker logs quipucords | grep -i "Running without supervisord"'
+    }}
+}}
 
 def setupQPC() {{
     sh '''\
@@ -26,12 +47,12 @@ def setupQPC() {{
 
     sh "tar -xvzf ${{WORKSPACE}}/quipucords.{release}.install.tar.gz"
 
-    echo "Execute install.sh to install"
-    dir("${{WORKSPACE}}/install") {{
-        sh 'pwd'
-        sh 'ls -l'
-        sh 'sudo ./install.sh -e server_install_dir=${{WORKSPACE}}'
+    if ('{install_type}' == 'nosupervisord') {{
+        installQPCNoSupervisorD()
+    }} else {{
+        installQPC()
     }}
+
 }}
 
 

--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -49,7 +49,9 @@
 - project:
     name: 'qpc-release-install-pipeline'
     jobs:
-      - 'qpc-{release}-install-pipeline'
+      - 'qpc-{release}-{install_type}-install-pipeline'
     release:
       - '0.0.46'
-
+    install_type:
+      - 'default'
+      - 'nosupervisord'

--- a/jjb/jobs/released-pipelines-template.yaml
+++ b/jjb/jobs/released-pipelines-template.yaml
@@ -1,6 +1,6 @@
 ---
 - job-template:
-    name: 'qpc-{release}-install-pipeline'
+    name: 'qpc-{release}-{install_type}-install-pipeline'
     project-type: pipeline
     sandbox: true
     triggers:


### PR DESCRIPTION
I added a conditional to create/run `nosupervisord` install tests pipelines.

- Broke up the `install.sh` command into two functions in the pipeline code. (one for default install, one for nosupervisord). This can be expanded to more cases in the future by adding more functions.
- The setupQPC() function just calls the appropriate install function based on the conditional (using the `install_type` variable.
- Edited pipeline template/project definition to include the `install_type` variable.
