### PR TITLE
Issues/123

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -65,6 +65,12 @@
 - project:
     name: quipucords-build-jobs
     jobs:
-      - '{repo}-build-job'
+      - '{repo}-{version}-build-job'
     repo:
       - 'quipucords'
+      - 'quipucords-ui'
+    version:
+      - 'master'
+      - '0.0.46':
+          branch: 'releases/0.0.46/'
+    branch: 'master'

--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -60,3 +60,11 @@
       - 'container'
       - 'default'
       - 'nosupervisord'
+
+
+- project:
+    name: quipucords-build-jobs
+    jobs:
+      - '{repo}-build-job'
+    repo:
+      - 'quipucords'

--- a/jjb/jobs/qpc-templates.yaml
+++ b/jjb/jobs/qpc-templates.yaml
@@ -14,7 +14,7 @@
 
 
 - job-template:
-    name: '{repo}-build-job'
+    name: '{repo}-{version}-build-job'
     project-type: pipeline
     sandbox: true
     triggers:
@@ -25,5 +25,5 @@
         - git:
             url: https://github.com/quipucords/{repo}.git
             branches:
-              - '*/master'
+              - '*/{branch}'
             skip-tag: true

--- a/jjb/jobs/qpc-templates.yaml
+++ b/jjb/jobs/qpc-templates.yaml
@@ -11,3 +11,19 @@
               - file-id: '62cf0ccc-220e-4177-9eab-f39701bff8d7'
                 target: 'camayoc/config.yaml'
     dsl: !include-raw: 'pipelines/qpc-tests-pipeline.groovy'
+
+
+- job-template:
+    name: '{repo}-build-job'
+    project-type: pipeline
+    sandbox: true
+    triggers:
+      - pollscm:
+          cron: '@hourly'
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/quipucords/{repo}.git
+            branches:
+              - '*/master'
+            skip-tag: true


### PR DESCRIPTION
When investigating Issue #123, it was found that the released container pipelines weren't pulling down the appropriate cli version to install (it just got latest from copr). This fix grabs the version from the install.sh script to match the cli version to the qpc-server version being used during the install stages.

Note, this solution is likely temporary as the methods used for both versioning and cli rpm hosting will likely change in the near future.