### PR TITLE
Added quipucords-installer builder job template

### DIFF
--- a/jjb/jobs/projects.yaml
+++ b/jjb/jobs/projects.yaml
@@ -69,6 +69,7 @@
     repo:
       - 'quipucords'
       - 'quipucords-ui'
+      - 'quipucords-installer'
     version:
       - 'master'
       - '0.0.46':


### PR DESCRIPTION
Added `quipucords-installer` to the build jobs jjb template. 

This template defines jobs that pull and build the `Jenkinsfile` from the various quipucords repos, for both `master` and defined release branches (currently just `0.0.46`).
This change adds the [quipucords-installer repo](https://github.com/quipucords/quipucords-installer) to that list. 

Note: This change job will only work for releases *after* `0.0.46`.