### PR TITLE
Issues/138 - Create a declarative test pipeline using the installer on rhel7 

### DIFF
--- a/jenkins/pipelines/test/qpc-test-pipeline.groovy
+++ b/jenkins/pipelines/test/qpc-test-pipeline.groovy
@@ -1,0 +1,87 @@
+pipeline {
+    agent { label 'f28-os' }
+
+environment {
+    qpc_version = getQPCVersion()
+    build_name = getBuildName()
+    image_name = "quipucords:${qpc_version}"
+    tarfile = "quipucords.${qpc_version}.tar"
+    targzfile = "${tarfile}.gz"
+    install_tar = "quipucords.install.tar"
+    install_targzfile = "${install_tar}.gz"
+}
+
+parameters {
+    string(defaultValue: "master", description: 'What version?', name: 'version_name')
+    choice(choices: ['branch', 'tag'], description: "Branch or Tag?", name: 'version_type')
+}
+
+stages {
+    stage('Build Info') {
+        steps {
+            echo "Version: ${params.version_name}\nVersion Type: ${params.version_type}\nCommit: ${env.GIT_COMMIT}\n\nBuild_version: ${env.build_version}"
+        }
+    }
+
+    stage('Setup System') {
+    	steps {
+			sh 'sudo dnf update'
+		}
+    }
+
+    stage('Setup Camayoc') {
+        steps {
+            // Setup Camayoc
+    		dir('camayoc') {
+       	 		git 'https://github.com/quipucords/camayoc.git'
+
+       	 		sh '''\
+    				python3 --version
+    				pipenv run make install-dev
+    			'''.stripIndent()
+    		}
+
+    		// Set pytest file
+    		sh '''\
+    			mkdir -p ~/.config/camayoc/
+    			cp camayoc/pytest.ini .
+    		'''.stripIndent()
+
+        	// Setup Camayoc Config File
+		    configFileProvider([configFile(fileId: '62cf0ccc-220e-4177-9eab-f39701bff8d7', targetLocation: '/home/jenkins/.config/camayoc/config.yaml')]) {
+        		sh '''\
+        			cat ~/.config/camayoc/config.yaml
+        			sed -i "s/{jenkins_slave_ip}/${OPENSTACK_PUBLIC_IP}/" ~/.config/camayoc/config.yaml
+        		'''.stripIndent()
+    		}
+
+    		sh 'python3.6 -m pip freeze'
+
+        }
+    }
+
+    stage('Run Camayoc Tests') {
+        steps {
+
+        // Set home dir to workspace dir
+        sh 'export XDG_CONFIG_HOME=$(pwd)'
+        sh 'ls -la ~'
+
+        dir('camayoc') {
+        	sh '''\
+        		#py.test -c pytest.ini -l -ra -s -vvv --junit-xml yupana-junit.xml --rootdir camayoc/camayoc/tests/qpc camayoc/camayoc/tests/qpc/yupana
+        		#pipenv run pytest -vvv --junit-xml yupana-junit.xml camayoc/tests/qpc/yupana
+			'''.stripIndent()
+			}
+        }
+    }
+
+    stage('Run Test Reports') {
+    	steps{
+    		dir('camayoc') {
+    			//junit 'yupana-junit.xml'
+    		}
+    	}
+    }
+}
+}

--- a/jenkins/pipelines/test/qpc-test-pipeline.groovy
+++ b/jenkins/pipelines/test/qpc-test-pipeline.groovy
@@ -1,14 +1,14 @@
 pipeline {
-    agent { label 'f28-os' }
+    agent { label 'rhel7-os' }
 
 environment {
-    qpc_version = getQPCVersion()
-    build_name = getBuildName()
-    image_name = "quipucords:${qpc_version}"
-    tarfile = "quipucords.${qpc_version}.tar"
-    targzfile = "${tarfile}.gz"
+    //qpc_version = getQPCVersion()
+    //build_name = getBuildName()
+    //image_name = "quipucords:${qpc_version}"
+    //tarfile = "quipucords.${qpc_version}.tar"
+    //targzfile = "${tarfile}.gz"
     install_tar = "quipucords.install.tar"
-    install_targzfile = "${install_tar}.gz"
+    //install_targzfile = "${install_tar}.gz"
 }
 
 parameters {
@@ -25,8 +25,13 @@ stages {
 
     stage('Setup System') {
     	steps {
-			sh 'sudo dnf update'
-		}
+            configFileProvider([configFile(fileId:
+                '0f157b1a-7068-4c75-a672-3b1b90f97ddd', targetLocation: 'rhel7-custom.repo')]) {
+			    sh 'sudo yum update -y'
+                sh 'sudo yum -y install python36 python36-pip'
+                sh 'python3 -m pip install pipenv --user'
+		    }
+        }
     }
 
     stage('Setup Camayoc') {
@@ -37,7 +42,7 @@ stages {
 
        	 		sh '''\
     				python3 --version
-    				pipenv run make install-dev
+    				python3 -m pipenv run make install-dev
     			'''.stripIndent()
     		}
 

--- a/jenkins/pipelines/test/qpc-test-pipeline.groovy
+++ b/jenkins/pipelines/test/qpc-test-pipeline.groovy
@@ -14,12 +14,14 @@ environment {
 parameters {
     string(defaultValue: "master", description: 'What version?', name: 'version_name')
     choice(choices: ['branch', 'tag'], description: "Branch or Tag?", name: 'version_type')
+    choice(choices: ['0.9.0', '0.9.1'], description: "Server Version", name: 'server_install_version')
+    choice(choices: ['0.9.0', '0.9.1'], description: "CLI Version", name: 'cli_install_version')
 }
 
 stages {
     stage('Build Info') {
         steps {
-            echo "Version: ${params.version_name}\nVersion Type: ${params.version_type}\nCommit: ${env.GIT_COMMIT}\n\nBuild_version: ${env.build_version}"
+            echo "Version: ${params.version_name}\nVersion Type: ${params.version_type}\nCommit: ${env.GIT_COMMIT}\n\nBuild_version: ${env.build_version}\n\nServer Install Version: ${params.server_install_version}\nCLI Install Version: ${params.cli_install_version}"
         }
     }
 
@@ -27,6 +29,18 @@ stages {
     	steps {
             install_deps()
             setupDocker()
+        }//end steps
+    }//end stage
+
+    stage('Install') {
+        steps {
+            echo "Install Server and CLI"
+            sh 'git clone https://github.com/quipucords/quipucords-installer.git'
+            dir('quipucords-installer/install') {
+                sh 'pwd'
+                sh 'ls -lah'
+                sh "./install.sh -e server_version=${params.server_install_version} -e cli_version=${params.cli_install_version}"
+            }//end dir
         }//end steps
     }//end stage
 

--- a/qpc-tests-pipeline.groovy
+++ b/qpc-tests-pipeline.groovy
@@ -1,0 +1,551 @@
+// {release} {install_type}
+
+def qpc_version = getQPCVersion()
+def image_name = "quipucords:${{qpc_version}}"
+def tarfile = "quipucords.${{qpc_version}}.tar"
+def targzfile = "${{tarfile}}.gz"
+def install_tar = "quipucords.install.tar"
+def install_targzfile = "${{install_tar}}.gz"
+
+def getQPCVersion() {{
+    if ('{release}' == 'master') {{
+        return "1.0.0"
+    }} else {{
+        return "{release}"
+    }}
+}}
+
+/////////////////////////
+//// Setup Functions ////
+/////////////////////////
+def setupDocker() {{
+    sh """\
+    echo "OPTIONS=--log-driver=journald" > docker.conf
+    echo "DOCKER_CERT_PATH=/etc/docker" >> docker.conf
+    echo "INSECURE_REGISTRY=\\"--insecure-registry \${{DOCKER_REGISTRY}}\\"" >> docker.conf
+    sudo cp docker.conf /etc/sysconfig/docker
+    """.stripIndent()
+}}
+
+
+
+/////////////////////////////////////
+//// Configure & Start Functions ////
+/////////////////////////////////////
+def startQPCServer = {{
+    sh """\
+    echo 'startQPCServer'
+    pwd
+    ls -lah
+    sudo systemctl start docker # Ensure docker running
+    QPC_DB=\$(sudo docker ps | grep qpc-db || true)
+    QPC_CONTAINER=\$(sudo docker ps | grep ${{image_name}} || true)
+
+    # Stop containers if they are running before restarting or testing
+    if [ \"\$QPC_DB\" != '' ] || [ \"\$QPC_CONTAINER\" != '' ]
+    then
+        sudo docker rm \$(sudo docker stop \$(sudo docker ps -aq))
+    fi
+    # Start up docker contaienrs
+    sudo docker run --name qpc-db -e POSTGRES_PASSWORD=password -d postgres:9.6.10
+    sudo docker run -d -p '9443:443' --link qpc-db:qpc-link \\
+        -e QPC_DBMS_HOST=qpc-db \\
+        -e QPC_DBMS_PASSWORD=password \\
+        -v /tmp:/tmp \
+        -v /home/jenkins/.ssh:/home/jenkins/.ssh \\
+        -v \${{PWD}}/log:/var/log \\
+        -i ${{image_name}}
+    """.stripIndent()
+
+    sh '''\
+    for i in {{1..30}}; do
+        SERVER_ID="$(curl -ks https://localhost:9443/api/v1/status/ | grep server_id || true)"
+
+        if [ "${{SERVER_ID}}" ]; then
+            break
+        fi
+
+        if [ $i -eq 30 ]; then
+            echo "Server took too long to start"
+            exit 1
+        fi
+
+        sleep 1
+    done
+    '''.stripIndent()
+}}
+
+
+
+//////////////////////////////
+//// Get Builds Functions ////
+//////////////////////////////
+def getQuipucords() {{
+    // get QPC
+    echo 'getQuipucords'
+    if ('{release}' == 'master') {{
+        getMasterQPC()
+    }} else {{
+        getReleasedQPC()
+    }}
+}}
+
+
+def getQuipucordsBuild() {{
+    // Grabs the quipucords build
+    sh 'ls -la'
+    echo "getQuipucords: Copying Latest build artifact..."
+    copyArtifacts filter: 'quipucords_server_image.tar.gz', fingerprintArtifacts: true,
+                  projectName: 'quipucords-{release}-build-job', selector: lastCompleted()
+
+    copyArtifacts filter: 'quipucords_install.tar.gz', fingerprintArtifacts:
+    true, projectName: 'quipucords-installer-{release}-build-job', selector: lastCompleted()
+
+    copyArtifacts filter: 'postgres.*.tar.gz', fingerprintArtifacts: true, projectName: 'quipucords-{release}-build-job', selector: lastCompleted()
+
+
+    sh 'ls -la'
+}}
+
+
+def getMasterQPC() {{
+    // Grabs the master qpc builds and sets it up
+    echo 'getMasterQPC'
+    def qpc_version = getQPCVersion()
+    getQuipucordsBuild()
+
+    sh 'ls -lah'
+    echo 'Extract the installer script'
+    sh """\
+    echo ${{qpc_version}}
+    tar -xvzf quipucords_install.tar.gz
+    """.stripIndent()
+
+    echo 'Copy container to installer packages directory'
+    sh '''\
+    mkdir -p install/packages
+    '''.stripIndent()
+}}
+
+
+def getReleasedQPC() {{
+    echo 'Get released QPC'
+    // Clean up QPC package if here...
+    sh '''\
+    ls -l
+    if [ -f quipucords.*tar.gz ]; then
+        rm quipucords.*.tar.gz
+    fi
+    '''.stripIndent()
+
+    // Pulls down Released Container
+    echo "load docker container from tarball"
+    sh "curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/{release}/quipucords.{release}.tar.gz"
+    // Pulls down Released Install
+    sh "curl -k -O -sSL https://github.com/quipucords/quipucords/releases/download/{release}/quipucords.{release}.install.tar.gz"
+
+    echo "extract the installer into ${{WORKSPACE}}/install"
+
+    sh "tar -xvzf ${{WORKSPACE}}/quipucords.{release}.install.tar.gz"
+}}
+
+
+
+///////////////////////////
+//// Install Functions ////
+///////////////////////////
+def installQPC(distro) {{
+    // Install QPC
+    if ('{install_type}' == 'nosupervisord') {{
+        installQPCNoSupervisorD()
+    }} else if ('{install_type}' == 'container') {{
+        containerInstall(distro)
+    }} else {{
+        defaultInstall()
+    }}
+}}
+
+
+def defaultInstall() {{
+    echo "Execute install.sh to install"
+    dir("${{WORKSPACE}}/install") {{
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'sudo ./install.sh -e server_install_dir=${{WORKSPACE}}'
+    }}
+}}
+
+
+def installQPCNoSupervisorD() {{
+    echo "Execute install.sh to install without supervisord"
+    dir("${{WORKSPACE}}/install") {{
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'sudo ./install.sh -e server_install_dir=${{WORKSPACE}} -e use_supervisord=false'
+
+        // Docker log to check for supervisord
+        sh 'sudo docker ps -a'
+        sh 'sudo docker logs quipucords | grep -i "Running without supervisord"'
+    }}
+}}
+
+
+def containerInstall(distro) {{
+    echo "Execute docker container install"
+    def qpc_version = getQPCVersion()
+    if (distro == 'rhel6') {{
+        echo 'No systemd, Docker should already be started.'
+    }} else {{
+        echo 'Starting Docker using Systemd'
+        sh 'sudo systemctl start docker'
+        sh 'sudo systemctl status docker'
+    }}
+
+    sh """\
+    sudo docker load -i quipucords_server_image.tar.gz
+    # make log dir to save server logs
+    mkdir -p log
+    """.stripIndent()
+}}
+
+
+def installQPCClient(distro) {{
+    // Install the qpc client
+    echo 'Install QPC Client'
+    // Pull Latest repo source from Copr
+    sh '''\
+    sudo wget -O /etc/yum.repos.d/group_quipucords-qpc-fedora-28.repo https://copr.fedorainfracloud.org/coprs/g/quipucords/qpc/repo/fedora-28/group_quipucords-qpc-fedora28.repo
+    ls -la /etc/yum.repos.d/
+    '''.stripIndent()
+
+    if ('{release}' == 'master') {{
+		installMasterQPCClient(distro)
+    }} else {{
+        installReleasedQPCClient()
+    }}
+
+}}
+
+def installMasterQPCClient(distro) {{
+	// Install latest qpc
+	if (distro ==~ /f\d\d/) {{
+		sh 'sudo dnf -y install qpc'
+	}} else {{
+		sh 'sudo yum -y install qpc'
+	}}
+}}
+
+
+def installReleasedQPCClient() {{
+    // Pulls down current released cli
+	dir("${{WORKSPACE}}/install") {{
+		sh '''\
+		CLI_VERSION=$(cat ./install.sh | grep CLI_PACKAGE_VERSION= | cut -d"=" -f3)
+		echo "${{CLI_VERSION: :-1}}"
+		wget -O qpc-client.rpm "https://github.com/quipucords/qpc/releases/download/0.0.46/qpc-${{CLI_VERSION: :-1}}.fc28.noarch.rpm"
+        ls -la
+        # Install the rpm
+        if grep -q -i "Fedora" /etc/redhat-release; then
+            sudo dnf install -y qpc-client.rpm
+        else
+            sudo yum install -y qpc-client.rpm
+        fi
+		'''.stripIndent()
+    }}
+}}
+
+
+
+////////////////////
+//// Test Setup ////
+////////////////////
+def setupScanUsers() {{
+    dir('ci') {{
+        git 'https://github.com/quipucords/ci.git'
+    }}
+
+    sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+        withCredentials([file(credentialsId: '50dc19ce-555f-422c-af38-3b5ede422bb4', variable: 'ID_JENKINS_RSA_PUB')]) {{
+            sh 'sudo dnf -y install ansible'
+
+            sh '''\
+            cat > jenkins-slave-hosts <<EOF
+            [jenkins-slave]
+            ${{OPENSTACK_PUBLIC_IP}}
+
+            [jenkins-slave:vars]
+            ansible_user=jenkins
+            ansible_ssh_extra_args=-o StrictHostKeyChecking=no
+            ssh_public_key_file=$(cat ${{ID_JENKINS_RSA_PUB}})
+            EOF
+            '''.stripIndent()
+
+            sh 'ansible-playbook -b -i jenkins-slave-hosts ci/ansible/sonar-setup-scan-users.yaml'
+        }}
+    }}
+}}
+
+
+def setupCamayoc() {{
+    dir('camayoc') {{
+        git 'https://github.com/quipucords/camayoc.git'
+    }}
+
+    sh '''\
+    sudo pip install ./camayoc[dev]
+    cp camayoc/pytest.ini .
+    '''.stripIndent()
+
+    withCredentials([file(credentialsId: '4c692211-c5e1-4354-8e1b-b9d0276c29d9', variable: 'ID_JENKINS_RSA')]) {{
+        sh '''\
+        mkdir -p /home/jenkins/.ssh
+        cp "${{ID_JENKINS_RSA}}" /home/jenkins/.ssh/id_rsa
+        chmod 0600 /home/jenkins/.ssh/id_rsa
+        '''.stripIndent()
+    }}
+
+    configFileProvider([configFile(fileId: '62cf0ccc-220e-4177-9eab-f39701bff8d7', targetLocation: 'camayoc/config.yaml')]) {{
+        sh '''\
+        sed -i "s/{{jenkins_slave_ip}}/${{OPENSTACK_PUBLIC_IP}}/" camayoc/config.yaml
+        '''.stripIndent()
+
+    }}
+}}
+
+
+
+////////////////////////
+//// Test Functions ////
+////////////////////////
+def runInstallTests(distro) {{
+    if (distro ==~ /f\d\d/) {{
+        sh 'sudo dnf -y install python-pip'
+    }} else {{
+        sh 'sudo yum -y install python-pip'
+    }}
+    if (distro == 'rhel6') {{
+        sh 'sudo pip install pexpect nose'
+
+        sh '''\
+        set +e
+        nosetests --with-xunit --xunit-file=junit.xml ci/scripts/quipucords/master/install/test_install.py
+        set -e
+        '''.stripIndent()
+    }} else {{
+        sh 'sudo pip install -U pip'
+        sh 'sudo pip install pexpect pytest'
+
+        sh """\
+        set +e
+        pytest --junit-prefix ${{distro}} --junit-xml junit.xml ci/scripts/quipucords/master/install/test_install.py
+        set -e
+        """.stripIndent()
+    }}
+
+    junit "junit.xml"
+}}
+
+
+def runCamayocTest(testset) {{
+    echo "Running ${{testset}} Tests"
+
+    sh 'cat camayoc/config.yaml'
+    sh 'ls -lah'
+    sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+        sh """
+        export XDG_CONFIG_HOME=\$(pwd)
+
+        set +e
+        py.test -c pytest.ini -l -ra -s -vvv --junit-xml $testset-junit.xml --rootdir camayoc/camayoc/tests/qpc camayoc/camayoc/tests/qpc/$testset
+        set -e
+
+        sudo docker rm \$(sudo docker stop \$(sudo docker ps -aq))
+        tar -cvzf test-$testset-logs.tar.gz log
+        sudo rm -rf log
+        """.stripIndent()
+    }}
+    echo 'Archiving artifacts'
+    archiveArtifacts "test-$testset-logs.tar.gz"
+    junit "$testset-junit.xml"
+}}
+
+
+def runCamayocUITest(browser) {{
+    echo "Running ${{browser}} Tests"
+
+    sh 'cat camayoc/config.yaml'
+    sh 'ls -lah'
+    sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+        sh "sudo docker run --net='host' -d -p 4444:4444 -v /dev/shm:/dev/shm:z -v /tmp:/tmp:z selenium/standalone-$browser"
+
+        sleep 3
+
+        sh """\
+        export XDG_CONFIG_HOME=\$PWD
+        export SELENIUM_DRIVER=$browser
+
+        set +e
+        py.test -c pytest.ini -l -ra -vvv --junit-prefix $browser --junit-xml ui-$browser-junit.xml --rootdir camayoc/camayoc/tests/qpc camayoc/camayoc/tests/qpc/ui
+        set -e
+
+        sudo docker rm \$(sudo docker stop \$(sudo docker ps -aq))
+        tar -cvzf test-ui-$browser-logs.tar.gz log
+        sudo rm -rf log
+        """.stripIndent()
+    }}
+
+    echo 'Archiving artifacts'
+    archiveArtifacts "test-ui-$browser-logs.tar.gz"
+    junit "ui-$browser-junit.xml"
+}}
+
+
+
+////////////////////////
+//// Pipeline Stage ////
+////////////////////////
+stage('Run Tests') {{
+    parallel 'CentOS 7 Install': {{
+        node('centos7-os') {{
+            stage('Centos7 Install') {{
+                dir('ci') {{
+                    git 'https://github.com/quipucords/ci.git'
+                }}
+
+                sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+                    withCredentials([file(credentialsId:
+                    '4c692211-c5e1-4354-8e1b-b9d0276c29d9', variable: 'ID_JENKINS_RSA')]) {{
+                        withEnv(['DISTRO=centos7', 'RELEASE={release}']) {{
+                            sh """\
+                            echo 'Testing qpc_version variable'
+                            echo ${{qpc_version}}
+                            """.stripIndent()
+                            echo "Testing inline qpc_version variable: ${{qpc_version}}"
+                            getQuipucords()
+                            installQPC 'centos7'
+                        }}
+                    }}
+                }}
+            }}
+        }}
+    }},
+
+
+    'Fedora 28': {{
+        node('f28-os') {{
+            stage('Fedora 28 Install') {{
+                dir('ci') {{
+                    git 'https://github.com/quipucords/ci.git'
+                }}
+
+                sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+                    withCredentials([file(credentialsId:
+                    '4c692211-c5e1-4354-8e1b-b9d0276c29d9', variable: 'ID_JENKINS_RSA')]) {{
+                        withEnv(['DISTRO=f28', 'RELEASE={release}']) {{
+                            echo 'Fedora 28: Configure Docker'
+                            setupDocker()
+                            getQuipucords()
+                            installQPC 'f28'
+                        }}
+                    }}
+                }}
+            }}
+
+            stage('F28: Setup Integration Tests') {{
+                echo 'Fedora 28: Install QPC Client'
+                installQPCClient 'f28'
+                echo 'Fedora 28: Setup Scan Users'
+                setupScanUsers()
+                echo 'Fedora 28: Setup Camayoc'
+                setupCamayoc()
+            }}
+
+            stage('F28: test api') {{
+                echo 'Fedora 28: Test API'
+                startQPCServer()
+                runCamayocTest 'api'
+            }}
+
+            stage('F28: Test CLI') {{
+                echo 'Fedora 28: Test CLI'
+                startQPCServer()
+                runCamayocTest 'cli'
+            }}
+
+            stage('F28: Test UI Chrome') {{
+                echo 'Fedora 28: Test UI Chrome'
+                startQPCServer()
+                runCamayocUITest 'chrome'
+            }}
+
+            stage('F28: Test UI Firefox') {{
+                echo 'Fedora 28: Test UI Firefox'
+                startQPCServer()
+                runCamayocUITest 'firefox'
+            }}
+
+            stage('F28: Install Tests') {{
+                runInstallTests 'f28'
+            }}
+         }}
+    }},
+
+    'RHEL6 Install': {{
+        node('rhel6-os') {{
+            stage('rhel6 Install') {{
+                dir('ci') {{
+                    git 'https://github.com/quipucords/ci.git'
+                }}
+
+                configFileProvider([configFile(fileId:
+                '5b276700-674e-4a0f-af91-3e725ed7a311', targetLocation: 'rhel6-custom.repo')]) {{
+                    sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+                        withCredentials([file(credentialsId:
+                        '4c692211-c5e1-4354-8e1b-b9d0276c29d9', variable: 'ID_JENKINS_RSA')]) {{
+                            withEnv(['DISTRO=rhel6', 'RELEASE={release}']) {{
+                                setupDocker()
+
+                                sh '''\
+                                sudo cp ${{WORKSPACE}}/rhel6-custom.repo /etc/yum.repos.d/rhel6-rcm-internal.repo
+                                sudo yum clean all
+                                sudo yum-config-manager --disable base
+                                sudo yum-config-manager --disable optional
+                                '''.stripIndent()
+
+                                getQuipucords()
+                                installQPC 'rhel6'
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+    }}, 'RHEL7 Install': {{
+        node('rhel7-os') {{
+            stage('rhel7 Install') {{ dir('ci') {{
+                    git 'https://github.com/quipucords/ci.git'
+                }}
+
+                configFileProvider([configFile(fileId:
+                '0f157b1a-7068-4c75-a672-3b1b90f97ddd', targetLocation: 'rhel7-custom.repo')]) {{
+                    sshagent(['390bdc1f-73c6-457e-81de-9e794478e0e']) {{
+                        withCredentials([file(credentialsId:
+                        '4c692211-c5e1-4354-8e1b-b9d0276c29d9', variable: 'ID_JENKINS_RSA')]) {{
+                            withEnv(['DISTRO=rhel7', 'RELEASE={release}']) {{
+                                echo 'Install Docker?'
+                                // TODO: Better solution
+                                sh 'sudo yum install docker -y'
+
+                                setupDocker()
+
+                                sh 'sudo cp rhel7-custom.repo /etc/yum.repos.d/rhel7-rcm-internal.repo'
+                                getQuipucords()
+                                installQPC 'rhel7'
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+    }}
+}}


### PR DESCRIPTION
Creates a declarative pipeline that runs the camayoc tests on a rhel7 node.

This first PR:
-  Defines the declarative pipeline (Closes #138) that can be supplied the CLI/Server versions of quipucords/qpc to run the tests against
- Switches to running the tests on a `rhel7` node (Closes #137)
- Uses the new installer to install and configure the server/cli being tested (passing the versions from the pipeline parameters) (Closes #131)
- Currently works using `0.9.0` version (Closes #117) 

Still WIP, to be added in future PRs:
- Fix podman related issues so test pipeline work with versions >= `0.9.1` (Issue #143)
- Add `rhel8` test node (Issue #144)
- Add offline install as a parameter (Issue #145)
- Add option to build/install server/cli from branches using the offline install case (Issue #146)
- Fix several out of date/failing tests