### PR TITLE
Updated defaults version to 0.9.2 for server and 0.9.3 for cli

### DIFF
--- a/jenkins/pipelines/test/qpc-dsc-test-pipeline.groovy
+++ b/jenkins/pipelines/test/qpc-dsc-test-pipeline.groovy
@@ -8,8 +8,8 @@ environment {
 parameters {
     choice(choices: ['qpc', 'dsc'], description: "Project (upstream vs downstream)", name: 'project')
     choice(choices: ['rhel8-os'], description: "Node OS", name: 'node_os')
-    string(defaultValue: '0.9.1', description: "Server Version", name: 'server_install_version')
-    string(defaultValue: '0.9.1', description: "CLI Version", name: 'cli_install_version')
+    string(defaultValue: '0.9.2', description: "Server Version", name: 'server_install_version')
+    string(defaultValue: '0.9.3', description: "CLI Version", name: 'cli_install_version')
 }
 
 stages {

--- a/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
+++ b/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
@@ -6,8 +6,8 @@ pipeline {
         choice(choices: ['both', 'qpc', 'dsc'], description: "Projects to run", name: 'projects')
         choice(choices: ['rhel8-os'], description: "Node OS", name: 'node_os')
         // Quipucords Params
-        string(defaultValue: '0.9.1', description: "Quipucords Server Version", name: 'qpc_server_install_version')
-        string(defaultValue: '0.9.1', description: "QPC CLI Version", name: 'qpc_cli_install_version')
+        string(defaultValue: '0.9.2', description: "Quipucords Server Version", name: 'qpc_server_install_version')
+        string(defaultValue: '0.9.3', description: "QPC CLI Version", name: 'qpc_cli_install_version')
         // Discovery Params
         string(defaultValue: '0.9.1', description: "Discovery Server Version", name: 'dsc_server_install_version')
         string(defaultValue: '0.9.1', description: "DSC CLI Version", name: 'dsc_cli_install_version')


### PR DESCRIPTION
Updated the default versions for the tests pipelines to use the `0.9.2` server and `0.9.3` cli versions.