### PR TITLE
Update discovery default versions

### DIFF
--- a/jenkins/pipelines/test/qpc-dsc-test-pipeline.groovy
+++ b/jenkins/pipelines/test/qpc-dsc-test-pipeline.groovy
@@ -124,7 +124,7 @@ def dsc_tools_install() {
     sh "pwd"
     sh "ls -lah"
     // Install CLI
-    sh "sudo dsc-tools cli install --home-dir ${workspace}"
+    sh "sudo dsc-tools cli install --version ${params.cli_install_version} --home-dir ${workspace}"
     // Install Server
     withCredentials([usernamePassword(credentialsId: 'test-account', passwordVariable: 'pass', usernameVariable: 'user')]) {
         // Call the dsc_server_install_cmd to generate the install command

--- a/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
+++ b/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
@@ -9,8 +9,8 @@ pipeline {
         string(defaultValue: '0.9.2', description: "Quipucords Server Version", name: 'qpc_server_install_version')
         string(defaultValue: '0.9.3', description: "QPC CLI Version", name: 'qpc_cli_install_version')
         // Discovery Params
-        string(defaultValue: '0.9.3', description: "Discovery Server Version", name: 'dsc_server_install_version')
-        string(defaultValue: '0.9.2', description: "DSC CLI Version", name: 'dsc_cli_install_version')
+        string(defaultValue: '0.9.2', description: "Discovery Server Version", name: 'dsc_server_install_version')
+        string(defaultValue: '0.9.3', description: "DSC CLI Version", name: 'dsc_cli_install_version')
     }
 
     stages {

--- a/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
+++ b/jenkins/pipelines/test/qpc-dsc-test-wrapper.groovy
@@ -9,8 +9,8 @@ pipeline {
         string(defaultValue: '0.9.2', description: "Quipucords Server Version", name: 'qpc_server_install_version')
         string(defaultValue: '0.9.3', description: "QPC CLI Version", name: 'qpc_cli_install_version')
         // Discovery Params
-        string(defaultValue: '0.9.1', description: "Discovery Server Version", name: 'dsc_server_install_version')
-        string(defaultValue: '0.9.1', description: "DSC CLI Version", name: 'dsc_cli_install_version')
+        string(defaultValue: '0.9.3', description: "Discovery Server Version", name: 'dsc_server_install_version')
+        string(defaultValue: '0.9.2', description: "DSC CLI Version", name: 'dsc_cli_install_version')
     }
 
     stages {


### PR DESCRIPTION
Now that the discovery runs are actually using the version variable, the version number being passed by the wrapper must be updated.